### PR TITLE
Run workflow security checks in parallel

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -25,12 +25,13 @@ jobs:
         with:
           aqua_version: v2.59.1
 
-      - name: Check action pinning
-        run: pinact run --check
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - parallel:
+          - name: Check action pinning
+            run: pinact run --check
+            env:
+              GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Audit workflows
-        run: zizmor --format github .
-        env:
-          GH_TOKEN: ${{ github.token }}
+          - name: Audit workflows
+            run: zizmor --format github .
+            env:
+              GH_TOKEN: ${{ github.token }}

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -5,4 +5,4 @@ registries:
     ref: v4.521.0 # renovate: depName=aquaproj/aqua-registry
 packages:
   - name: suzuki-shunsuke/pinact@v4.0.0
-  - name: zizmorcore/zizmor@v1.25.2
+  - name: zizmorcore/zizmor@v1.27.0


### PR DESCRIPTION
## Summary

- run independent GitHub Actions security checks concurrently
- update zizmor to v1.27.0 for experimental parallel-step support

## Verification

- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor --format github .`